### PR TITLE
add support for colors

### DIFF
--- a/qml/component/message/reply/MessageReplyItem.qml
+++ b/qml/component/message/reply/MessageReplyItem.qml
@@ -9,6 +9,7 @@ Item
                                                      lblmessage.calculatedWidth)
 
     property alias quoteColor: messagequote.color
+    property alias fromColor: lblfrom.color
 
     id: messagereplyitem
     height: Math.max(previewcontent.height, mediamessageitem.height)

--- a/qml/item/MessageModelItem.qml
+++ b/qml/item/MessageModelItem.qml
@@ -4,6 +4,7 @@ import "../component/theme"
 import "../component/message"
 import "../component/message/reply"
 import "../component/message/media"
+import "../js/Colors.js" as Colors
 
 Item
 {
@@ -85,6 +86,7 @@ Item
             width: parent.width
             horizontalAlignment: Text.AlignLeft
             rawText: model.messageFrom
+            color: Colors.getColor(model.item.fromId)
         }
 
         MessageReplyItem
@@ -92,6 +94,7 @@ Item
             id: messagereply
             width: parent.width
             quoteColor: model.isMessageOut ? Theme.mainColor : Theme.alternateMainColor
+            fromColor: model.messageHasReply ? Colors.getColor(model.replyItem.fromId) : "black"
             visible: model.messageHasReply
         }
 

--- a/qml/js/Colors.js
+++ b/qml/js/Colors.js
@@ -1,0 +1,17 @@
+.pragma library
+
+var AVATARS = [
+    "papayawhip",
+    "black",
+    "purple",
+    "green",
+    "yellow",
+    "indianred",
+    "brown",
+    "olivedrab",
+]
+
+function getColor(userId) {
+    return AVATARS[userId % 8];
+}
+

--- a/qml/view/subview/MessagesView.qml
+++ b/qml/view/subview/MessagesView.qml
@@ -4,6 +4,7 @@ import "../../component"
 import "../../component/theme"
 import "../../component/message"
 import "../../item"
+import "../../js/Colors.js" as Colors
 
 ViewContainer
 {
@@ -60,11 +61,11 @@ ViewContainer
                 {
                     id: peerimage
                     size: Theme.itemSizeSmall
-                    peer: model.needsPeerImage ? model.item : null
                     visible: model.needsPeerImage
-                    backgroundColor: "gray"
+                    backgroundColor: Colors.getColor(model.item.fromId)
                     foregroundColor: "black"
                     fontPixelSize: Theme.fontSizeSmall
+                    peer: model.needsPeerImage ? model.item : null
                 }
             }
 


### PR DESCRIPTION
The colors are not the most beautiful ones, however, it's hard to find good ones on this background.

Also I noticed that qquickpeerimage has an issue in the way it initializes... The color must be set *before* the peer, or it won't pick it up. I think the initializing needs to be changed to make it inherit QQuickParserStatus and only initialize once all the properties are set.